### PR TITLE
fixes #43 - removes Injection of RXErrorEventBusLifecycleObserver

### DIFF
--- a/ICT4DNews/app/src/main/java/at/ict4d/ict4dnews/lifecycle/RXErrorEventBusLifecycleObserver.kt
+++ b/ICT4DNews/app/src/main/java/at/ict4d/ict4dnews/lifecycle/RXErrorEventBusLifecycleObserver.kt
@@ -11,9 +11,8 @@ import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 import org.jetbrains.anko.toast
 import timber.log.Timber
-import javax.inject.Inject
 
-class RXErrorEventBusLifecycleObserver @Inject constructor(
+class RXErrorEventBusLifecycleObserver(
     private val activity: AppCompatActivity,
     private val compositeDisposable: CompositeDisposable,
     private val eventBus: RxEventBus

--- a/ICT4DNews/app/src/main/java/at/ict4d/ict4dnews/lifecycle/RXLifecycleObserver.kt
+++ b/ICT4DNews/app/src/main/java/at/ict4d/ict4dnews/lifecycle/RXLifecycleObserver.kt
@@ -4,9 +4,8 @@ import android.arch.lifecycle.Lifecycle
 import android.arch.lifecycle.LifecycleObserver
 import android.arch.lifecycle.OnLifecycleEvent
 import io.reactivex.disposables.CompositeDisposable
-import javax.inject.Inject
 
-open class RXLifecycleObserver @Inject constructor(
+open class RXLifecycleObserver(
     private val compositeDisposable: CompositeDisposable
 ) : LifecycleObserver {
 

--- a/ICT4DNews/app/src/main/java/at/ict4d/ict4dnews/screens/base/BaseActivity.kt
+++ b/ICT4DNews/app/src/main/java/at/ict4d/ict4dnews/screens/base/BaseActivity.kt
@@ -11,6 +11,7 @@ import android.support.v4.app.Fragment
 import android.support.v7.app.AppCompatActivity
 import at.ict4d.ict4dnews.R
 import at.ict4d.ict4dnews.lifecycle.RXErrorEventBusLifecycleObserver
+import at.ict4d.ict4dnews.utils.RxEventBus
 import dagger.android.AndroidInjection
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.support.HasSupportFragmentInjector
@@ -33,7 +34,7 @@ abstract class BaseActivity<V : ViewModel, B : ViewDataBinding> : AppCompatActiv
     protected lateinit var viewModelFactory: ViewModelProvider.Factory
 
     @Inject
-    protected lateinit var rxErrorEventBusLifecycleObserver: RXErrorEventBusLifecycleObserver
+    protected lateinit var rxEventBus: RxEventBus
 
     /**
      * return the layout id associated with the Activity
@@ -53,7 +54,7 @@ abstract class BaseActivity<V : ViewModel, B : ViewDataBinding> : AppCompatActiv
         model = ViewModelProviders.of(this, viewModelFactory).get(getViewModel())
 
         setSupportActionBar(binding.root.findViewById(R.id.toolbar))
-        lifecycle.addObserver(rxErrorEventBusLifecycleObserver)
+        lifecycle.addObserver(RXErrorEventBusLifecycleObserver(this, compositeDisposable, rxEventBus))
     }
 
     override fun supportFragmentInjector() = fragmentInjector


### PR DESCRIPTION
The CompositeDisposable was injected and not the same as in the Activity where all the Subscriptions were registered into a different CompositeDisposable object. It was therefore never disposed. I found this bug in SportsID... was hard to find 😄 