### PR TITLE
fixes #180 - sets back OKHttp since OkHttp 3.13+ requires API 21+

### DIFF
--- a/ICT4DNews/app/build.gradle
+++ b/ICT4DNews/app/build.gradle
@@ -126,6 +126,9 @@ dependencies {
     implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.core:core-ktx:1.0.1"
 
+    // Play Services
+    implementation "com.google.android.gms:play-services-auth:16.0.1"
+
     // Dagger 2
     implementation "com.google.dagger:dagger-android:$dagger_version"
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
@@ -153,7 +156,7 @@ dependencies {
     // Retrofit
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofit_version"
-    implementation "com.squareup.okhttp3:logging-interceptor:3.13.1"
+    implementation "com.squareup.okhttp3:logging-interceptor:3.12.2" // do not update since OkHttp 3.13+ requires API 21+
     implementation "com.squareup.retrofit2:converter-simplexml:2.3.0"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
 

--- a/ICT4DNews/app/src/main/kotlin/at/ict4d/ict4dnews/dagger/modules/ApiServiceModule.kt
+++ b/ICT4DNews/app/src/main/kotlin/at/ict4d/ict4dnews/dagger/modules/ApiServiceModule.kt
@@ -28,6 +28,11 @@ import java.io.File
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException
+import com.google.android.gms.common.GooglePlayServicesUtil
+import com.google.android.gms.common.GooglePlayServicesRepairableException
+import com.google.android.gms.security.ProviderInstaller
+import timber.log.Timber
 
 @Module
 abstract class ApiServiceModule {
@@ -87,7 +92,10 @@ abstract class ApiServiceModule {
         @Provides
         @JvmStatic
         @Singleton
-        fun provideOkHttpClient(cache: Cache, httpLoggingInterceptor: HttpLoggingInterceptor): OkHttpClient {
+        fun provideOkHttpClient(
+            cache: Cache,
+            httpLoggingInterceptor: HttpLoggingInterceptor,
+            application: ICT4DNewsApplication): OkHttpClient {
             val builder = OkHttpClient.Builder()
                 .cache(cache)
                 .connectTimeout(30, TimeUnit.SECONDS)
@@ -97,6 +105,12 @@ abstract class ApiServiceModule {
 
             if (BuildConfig.DEBUG) {
                 builder.addNetworkInterceptor(StethoInterceptor())
+            }
+
+            try {
+                ProviderInstaller.installIfNeeded(application)
+            } catch (e: Exception) {
+                Timber.e("SecurityException: Google Play Services not available.")
             }
 
             return builder.build()

--- a/ICT4DNews/app/src/main/play/release-notes/de-De/production.txt
+++ b/ICT4DNews/app/src/main/play/release-notes/de-De/production.txt
@@ -1,0 +1,1 @@
+• Erste Veröffentlichung

--- a/ICT4DNews/app/src/main/play/release-notes/en-GB/production.txt
+++ b/ICT4DNews/app/src/main/play/release-notes/en-GB/production.txt
@@ -1,0 +1,1 @@
+• First release

--- a/ICT4DNews/build.gradle
+++ b/ICT4DNews/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         versionMajor = 1
         versionMinor = 1
         versionPatch = 0
-        versionBuild = 2 // bump for dogfood builds, public betas, etc.
+        versionBuild = 3 // bump for dogfood builds, public betas, etc.
         versionCode = versionMajor * 10000 + versionMinor * 1000 + versionPatch * 100 + versionBuild
 
         kotlin_version = "1.3.21"


### PR DESCRIPTION
The new okHttp lib crashes on older devices, since OkHttp 3.13+ requires API 21+
There is also a SSL certificate problem. I don't have a device with Android <21, anybody can test this?

The app should now open and download all news. @jguitiche I thing you could test this, no? @rajasone do you have a <21 devices with Google Play Services installed?