### PR TITLE
fixes #195 and fixes #171 - adds proper error handling for.…

### DIFF
--- a/ICT4DNews/app/src/main/kotlin/at/ict4d/ict4dnews/server/Server.kt
+++ b/ICT4DNews/app/src/main/kotlin/at/ict4d/ict4dnews/server/Server.kt
@@ -58,7 +58,7 @@ class Server(
                 )
             } else if (blog.feedType == FeedType.RSS || blog.feedType == FeedType.WORDPRESS_COM) {
                 requests.add(apiRSSService.getRssNews(blog.feed_url)
-                    .doOnError { return@doOnError }
+                    .onErrorReturn { RSSFeed() }
                 )
             }
         }


### PR DESCRIPTION
Wordpress.com blogs to not break the chain when something goes wrong. App should now download all available news again when a new install happens